### PR TITLE
Resume audio context after user interaction

### DIFF
--- a/js/ScaleBlitz.js
+++ b/js/ScaleBlitz.js
@@ -55,6 +55,11 @@ var ScaleBlitz = (function () {
           $("#bpm").change(function(){
               ScalePlayer.changeTempo($(this).val());
           });
+
+          // Chrome prevents audio context from starting without user insteraction, resume the context after first mousedown event
+          document.addEventListener("mousedown", function(){
+            if (Tone.context.state !== 'running') Tone.context.resume();
+          },  { once: true });
     }
     
     function getScales(){

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -127,6 +127,11 @@ var ScaleBlitz = (function () {
           $("#bpm").change(function(){
               ScalePlayer.changeTempo($(this).val());
           });
+
+          // Chrome prevents audio context from starting without user insteraction, resume the context after first mousedown event
+          document.addEventListener("mousedown", function(){
+            if (Tone.context.state !== 'running') Tone.context.resume();
+          },  { once: true });
     }
     
     function getScales(){


### PR DESCRIPTION
Site was broken on Chrome because the AudioContext was not allowed to start before user interaction. Change resumes the AudioContext after the user's first mouse down event on the page.